### PR TITLE
Small tweaks to cost estimator

### DIFF
--- a/notebooks/workflow_cost_estimator/main.py
+++ b/notebooks/workflow_cost_estimator/main.py
@@ -95,6 +95,7 @@ with herzog.Cell("python"):
               "%7s" % ("$%.2f" % shard_info['cost']))
         shard_info['duration'] /= 3600  # convert from seconds to hours
     print("%108s" % ("total_cost: $%.2f" % round(total_cost, 2)))
+    # If the output here is blank, your submission probably hasn't started yet. Try re-running this notebook in a few minutes.
 
 with herzog.Cell("markdown"):
     """

--- a/notebooks/workflow_cost_estimator/main.py
+++ b/notebooks/workflow_cost_estimator/main.py
@@ -49,12 +49,17 @@ with herzog.Cell("python"):
                             workspace_namespace: str=WORKSPACE_GOOGLE_PROJECT):
         workflows_metadata = workflows.get_all_workflows(submission_id, workspace, workspace_namespace)
         for workflow_id, workflow_metadata in workflows_metadata.items():
-            shard_number = 1  # keep track of scattered workflows
-            for shard_info in workflows.estimate_workflow_cost(workflow_id, workflow_metadata):
-                shard_info['workflow_id'] = workflow_id
-                shard_info['shard'] = shard_number
-                shard_number += 1
-                yield shard_info
+            if "Submitted" == workflow_metadata['status']:
+                print("Workflow has submitted status, cost estimates may be unavailable")
+            elif "Failed" == workflow_metadata['status']:
+                print("No workflow IDs found, submission has status failed.")
+            else:
+                shard_number = 1  # keep track of scattered workflows
+                for shard_info in workflows.estimate_workflow_cost(workflow_id, workflow_metadata):
+                    shard_info['workflow_id'] = workflow_id
+                    shard_info['shard'] = shard_number
+                    shard_number += 1
+                    yield shard_info
 
     def estimate_job_cost(cpus: int, memory_gb: int, disk_gb: int, runtime_hours: float, preemptible: bool) -> float:
         disk = costs.PersistentDisk.estimate(disk_gb, runtime_hours * 3600)
@@ -73,6 +78,18 @@ with herzog.Cell("python"):
 # Insert a test submission id
 submission_id = "7d4d4bbd-6d3a-4e8f-848d-3992f5bd8e33"
 # TODO: workflow metadata expires after 40 days, which will cause this test to break. Is there a better way?
+
+with herzog.Cell("markdown"):
+    """
+    Some possible errors you may run into when running the next cells:
+
+    1. If you get a HTTP error, the submission cannot be found. Make sure you are entering a submission ID, not a workflow ID.
+    2. If you get a note about there being no workflow IDs and the status being failed, your workflow was cancelled before even running. Usually, this is because Terra detected invalid inputs.
+    3. If you get a note about submitted status, and no other information, then your workflow has not started yet. Try waiting a few minutes.
+
+
+    Terra's ability to detect invalid inputs tends to be fast, so it is unlikely for cases 2 and 3 overlap.
+    """
 
 with herzog.Cell("python"):
     # submission_id = "388beeb8-5e44-4215-8a71-89f2625fbc45"  # Uncomment and insert your submission id here


### PR DESCRIPTION
I've other changes planned but that'll require editing this and TNU so let's get this small thing out of the way first.

Basically this better handles two cases:
1. The user tries to check an invalid submission that didn't even get to the stage of being assigned a workflow ID before Terra said "nah"
2. The user tries to check a valid submission immediately after submitting it

Cases 1 and 2 should have no overlap because Terra's validation of workflow inputs is basically immediate.