### PR TITLE
Updates for new tnu table features

### DIFF
--- a/notebooks/xvcfmerge_array_input/main.py
+++ b/notebooks/xvcfmerge_array_input/main.py
@@ -124,7 +124,7 @@ with herzog.Cell("markdown"):
     - `gs://[bucket-name]/key/to/my/b-chr2.vcf.gz`
     """
 
-table.delete("vcf-merge-input-bucket")
+table.delete("vcf-merge-input-mixed")
 with herzog.Cell("python"):
     table_name = "vcf-merge-input-mixed"
     table.put_row(table_name,

--- a/notebooks/xvcfmerge_array_input/main.py
+++ b/notebooks/xvcfmerge_array_input/main.py
@@ -36,7 +36,7 @@ with herzog.Cell("markdown"):
 
     Runtime and cost can vary greatly depending on the size and number of intput files. Sample runtime and cost
     information is available for previous merge workflows in
-    [NHLBI BioData Catalyst / Utilities](https://dockstore.org/organizations/bdcatalyst/collections/Utilities) for
+    [NHLBI BioData Catalyst / Utilities](https://dockstore.org/organizations/bdcatalyst/collections/Utilities).
 
     ### Input File Requirements
 

--- a/notebooks/xvcfmerge_array_input/main.py
+++ b/notebooks/xvcfmerge_array_input/main.py
@@ -5,14 +5,16 @@ from firecloud import fiss
 
 with herzog.Cell("markdown"):
     """
+    # VCF Merge Workflow Input Preparation
+
     This notebook demonstrates the creation of Terra data tables as input to xvcfmerge workflows, referencing input
-    VCFs with an `Array[String]` of either DRS URIs or Google Storage URLs, and is meant to be used with the xvcfmerge
+    VCFs with an `Array[String]` of DRS URIs or Google Storage URLs, and is meant to be used with the xvcfmerge
     version [xbrianh-input-format](https://dockstore.org/workflows/github.com/DataBiosphere/xvcfmerge:v0.1.0?tab=info).
 
     This version of the xvcfmerge changes input format from a comma separated `String` of Google Storage URLs (gs://) to an
     `Array[String]` of either DRS URIs (drs://) or Google Storage URLs (gs://). It is currently in beta.
 
-    # Cohort VCF Merge
+    ## Cohort VCF Merge
 
     TopMED multi-sample VCF files indexed by BioData Catalyst have been jointly called for each "Freeze", or release of
     genomic data. These files are accessible in the "Reference File" node of the Gen3 graph. TOPMed researchers not
@@ -27,12 +29,20 @@ with herzog.Cell("markdown"):
     the tar.gz to your workspace using the utilities found in the
     [unarchive-tar-files-to-workspace notebook](https://app.terra.bio/terra.biodatacatalyst.nhlbi.nih.gov/#workspaces/biodata-catalyst/BioData%20Catalyst%20Collection/notebooks/launch/unarchive-tar-files-to-workspace.ipynb).
 
-    ## Workflows
+    ### Workflows
 
     Import the [Dockstore](https://dockstore.org) workflows into your workspace using the "NHLBI Biodata Catalyst" launch button:
      - [xvcfmerge](https://dockstore.org/workflows/github.com/DataBiosphere/xvcfmerge:v0.1.0?tab=info)
 
-    Workflow execution time is typically ~20 minutes per VCF.
+    Runtime and cost can vary greatly depending on the size and number of intput files. Sample runtime and cost
+    information is available for previous merge workflows in
+    [NHLBI BioData Catalyst / Utilities](https://dockstore.org/organizations/bdcatalyst/collections/Utilities) for
+
+    ### Input File Requirements
+
+    - Input files _must_ be referenced with either DRS URIs or Google bucket URLs.
+    - Output files _must_ be Google bucket URLs. The target bucket will usually be your workspace bucket, but it can be
+      any bucket for which you have write access.
     """
 
 os.environ['WORKSPACE_NAME'] = "terra-notebook-utils-tests"
@@ -53,8 +63,8 @@ with herzog.Cell("python"):
 
 with herzog.Cell("markdown"):
     """
-    ## Option A: Prepare the merge workflow input data table for DRS URIs
-    This is a typical workflow preparation for merging TOPMed VCFs _without_ downloading them to your workspace bucket.
+    ## Option A: VCF merge workflow input for DRS URIs
+    This is a typical workflow preparation for merging TOPMed VCFs _without_ downloading them to your workspace.
     Results will be placed in your workspace bucket.
     """
 
@@ -74,15 +84,16 @@ with herzog.Cell("python"):
 
 with herzog.Cell("markdown"):
     """
-    ## Option B: Prepare the merge workflow input data table for VCFs already in bucket
-    This workflow preparation uses VCFs that are present in your workspace bucket. Results will be placed in your workspace bucket.
+    ## Option B: VCF merge workflow input for Google bucket URLs
+    This workflow preparation uses VCFs that are available in a Google bucket. Results will be placed in your
+    workspace bucket.
 
-    Make sure that they follow the following format:
-    `gs://[your-bucket's-name]/vcfsa/chr1.vcf.gz`
-    `gs://[your-bucket's-name]/vcfsa/chr2.vcf.gz`
-    `..`
-    `gs://[your-bucket's-name]/vcfsb/chr1.vcf.gz`
-    `gs://[your-bucket's-name]/vcfsb/chr2.vcf.gz`
+    Google bucket URLs should have the following format:
+    - `gs://[bucket-name]/key/to/my/a-chr1.vcf.gz`
+    - `gs://[bucket-name]/key/to/my/a-chr2.vcf.gz`
+    - `..`
+    - `gs://[bucket-name]/key/to/my/b-chr1.vcf.gz`
+    - `gs://[bucket-name]/key/to/my/b-chr2.vcf.gz`
     """
 
 table.delete("vcf-merge-input-bucket")
@@ -98,6 +109,36 @@ with herzog.Cell("python"):
                                    inputs=[f"{workspace_bucket}/vcfsa/chr2.vcf.gz",
                                            f"{workspace_bucket}/vcfsb/chr2.vcf.gz"],
                                    output=f"{workspace_bucket}/merged/chr2.vcf.gz"))
+
+with herzog.Cell("markdown"):
+    """
+    ## Option C: VCF merge workflow input for mixed Google bucket URLs and DRS URIs
+    This workflow preparation uses VCFs that are referenced with either Google bucket URLs or DRS URIs.
+    Results will be placed in your workspace bucket.
+
+    Google bucket URLs should have the following format:
+    - `gs://[bucket-name]/key/to/my/a-chr1.vcf.gz`
+    - `gs://[bucket-name]/key/to/my/a-chr2.vcf.gz`
+    - `..`
+    - `gs://[bucket-name]/key/to/my/b-chr1.vcf.gz`
+    - `gs://[bucket-name]/key/to/my/b-chr2.vcf.gz`
+    """
+
+table.delete("vcf-merge-input-bucket")
+with herzog.Cell("python"):
+    table_name = "vcf-merge-input-mixed"
+    table.put_row(table_name,
+                  dict(workspace=workspace,
+                       billing_project=workspace_namespace,
+                       inputs=["drs://dg.4503/697f611b-aa8a-4bd7-a80b-946276273833",
+                               f"{workspace_bucket}/vcfs_to_merge/ce212b62-e796-4b32-becb-361f272cead0.vcf.g"],
+                       output=f"{workspace_bucket}/merged/mixed.vcf.gz"))
+    table.put_row(table_name,
+                  dict(workspace=workspace,
+                       billing_project=workspace_namespace,
+                       inputs=["drs://dg.4503/93286e47-3d09-47e6-ac87-4c2975ef0c3f",
+                               f"{workspace_bucket}/vcfs_to_merge/aba6b011-2ab4-4739-beb4-c1eeaee60c74.vcf.gz"],
+                       output=f"{workspace_bucket}/merged/mixed.vcf.gz"))
 
 
 ################################################ TESTS ################################################ noqa

--- a/notebooks/xvcfmerge_array_input/requirements.txt
+++ b/notebooks/xvcfmerge_array_input/requirements.txt
@@ -1,2 +1,2 @@
-terra-notebook-utils
+terra-notebook-utils >= 0.8.1, < 0.9.0
 herzog >= 0.0.2, < 0.1.0


### PR DESCRIPTION
This uses [terra-notebook-utils](https://github.com/DataBiosphere/terra-notebook-utils) Terra data table features to simplify [xvcfmerge](https://github.com/DataBiosphere/xvcfmerge) input table creation.

Note that this notebook supersedes [VCF Merge and Subsample Tutorial](https://github.com/DataBiosphere/featured-notebooks/blob/master/notebooks/vcf_merge_subsample_tutorial/main.py), which should be deleted from the BioData Catalyst collection when this PR is merged, and when the [xvcfsubsample](https://github.com/DataBiosphere/xvcfsubsample) example notebook is complete.