### PR TITLE
Regenerate gitlab yaml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,12 +84,6 @@ prepare_igv_viewer_input:
     NOTEBOOK: "prepare_igv_viewer_input"
     IMAGE: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.17
 
-vcf_merge_subsample_tutorial:
-  extends: .notebook-test
-  variables:
-    NOTEBOOK: "vcf_merge_subsample_tutorial"
-    IMAGE: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.17
-
 workflow_cost_estimator:
   extends: .notebook-test
   variables:


### PR DESCRIPTION
I just ran
```
./scripts/generate_gitlab_yml.sh .gitlab-ci.yml 
```
because the yml was out of sync and causing the pipeline to fail. Now the pipline should be able to test the other notebooks.